### PR TITLE
Downgrade reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ sha2 = "0.9.3"
 hex = "0.4.2"
 
 [dependencies.reqwest]
-version = "0.11.1"
+version = "0.10.10"
 features = ["json"]
 
 [dependencies.chrono]


### PR DESCRIPTION
The downgrade is being done because
we need to support tokio 0.2 and not 1.0
on main server.
